### PR TITLE
feat!: don't prepend signature scheme flag before public key

### DIFF
--- a/rust-app/src/implementation.rs
+++ b/rust-app/src/implementation.rs
@@ -27,10 +27,8 @@ impl Address<SuiPubKeyAddress, ledger_device_sdk::ecc::ECPublicKey<65, 'E'>> for
         key: &ledger_device_sdk::ecc::ECPublicKey<65, 'E'>,
     ) -> Result<Self, SyscallError> {
         let key_bytes = ed25519_public_key_bytes(key);
-        let mut tmp = ArrayVec::<u8, 32>::new();
-        let _ = tmp.try_extend_from_slice(key_bytes);
         let mut hasher: Blake2b = Hasher::new();
-        hasher.update(&tmp);
+        hasher.update(&key_bytes);
         let hash: [u8; SUI_ADDRESS_LENGTH] = hasher.finalize();
         Ok(SuiPubKeyAddress(key.clone(), hash))
     }


### PR DESCRIPTION
Don't prepend signature scheme flag before Ed25519 public keys as this wouldn't result in IOTA addresses

Fixes #2 