### PR TITLE
feat: remove wildcard imports

### DIFF
--- a/rust-app/bin-src/main.rs
+++ b/rust-app/bin-src/main.rs
@@ -4,7 +4,7 @@
 #[cfg(not(target_family = "bolos"))]
 fn main() {}
 
-use iota::main_nanos::*;
+use iota::main_nanos::app_main;
 
 ledger_device_sdk::set_panic!(ledger_device_sdk::exiting_panic);
 

--- a/rust-app/src/implementation.rs
+++ b/rust-app/src/implementation.rs
@@ -1,7 +1,11 @@
-use crate::interface::*;
-use crate::settings::*;
-use crate::utils::*;
-use alamgu_async_block::*;
+use crate::interface::{
+    Amount, ArgumentSchema, Bip32Key, CallArgSchema, CommandSchema, EpochId, GasData, Ins, Intent,
+    IntentMessage, ObjectRef, ProgrammableTransaction, Recipient, SharedObject, TransactionData,
+    TransactionDataV1, TransactionExpiration, TransactionKind, IOTA_ADDRESS_LENGTH, U16LE,
+};
+use crate::settings::Settings;
+use crate::utils::{scroller, scroller_paginated, NoinlineFut};
+use alamgu_async_block::{ByteStream, HostIO};
 use arrayvec::ArrayString;
 use arrayvec::ArrayVec;
 use core::fmt::Write;
@@ -10,9 +14,11 @@ use ledger_crypto_helpers::eddsa::{ed25519_public_key_bytes, eddsa_sign, with_pu
 use ledger_crypto_helpers::hasher::{Blake2b, Hasher, HexHash};
 use ledger_device_sdk::io::{StatusWords, SyscallError};
 use ledger_log::trace;
-use ledger_parser_combinators::async_parser::*;
-use ledger_parser_combinators::bcs::async_parser::*;
-use ledger_parser_combinators::interp::*;
+use ledger_parser_combinators::async_parser::{
+    reject, reject_on, AsyncParser, HasOutput, Readable, TryFuture,
+};
+use ledger_parser_combinators::bcs::async_parser::{Vec, ULEB128};
+use ledger_parser_combinators::interp::{Action, DefaultInterp, SubInterp};
 use ledger_prompts_ui::{final_accept_prompt, ScrollerError};
 
 use core::convert::TryFrom;

--- a/rust-app/src/interface.rs
+++ b/rust-app/src/interface.rs
@@ -1,8 +1,8 @@
 use core::convert::TryFrom;
 use ledger_device_sdk::io::{ApduHeader, StatusWords};
-use ledger_parser_combinators::bcs::async_parser::*;
-use ledger_parser_combinators::core_parsers::*;
-use ledger_parser_combinators::endianness::*;
+use ledger_parser_combinators::bcs::async_parser::{Vec, ULEB128};
+use ledger_parser_combinators::core_parsers::{Array, Byte, DArray, U16, U32, U64};
+use ledger_parser_combinators::endianness::Endianness;
 use num_enum::TryFromPrimitive;
 
 // Payload for a public key request

--- a/rust-app/src/lib.rs
+++ b/rust-app/src/lib.rs
@@ -17,8 +17,6 @@
 #![cfg_attr(all(not(version("1.65"))), feature(generic_associated_types))]
 #![cfg_attr(version("1.71"), feature(impl_trait_in_assoc_type))]
 
-pub use ledger_log::*;
-
 #[cfg(feature = "pending_review_screen")]
 mod pending;
 

--- a/rust-app/src/main_nanos.rs
+++ b/rust-app/src/main_nanos.rs
@@ -1,9 +1,9 @@
-use crate::implementation::*;
-use crate::interface::*;
-use crate::menu::*;
-use crate::settings::*;
+use crate::implementation::{handle_apdu_async, APDUsFuture};
+use crate::interface::Ins;
+use crate::menu::{BusyMenu, IdleMenu, IdleMenuWithSettings};
+use crate::settings::Settings;
 
-use alamgu_async_block::*;
+use alamgu_async_block::{poll_apdu_handlers, HostIO, HostIOState};
 
 use ledger_device_sdk::io;
 use ledger_device_sdk::uxapp::{UxEvent, BOLOS_UX_OK};
@@ -12,7 +12,7 @@ use ledger_prompts_ui::{handle_menu_button_event, show_menu};
 
 use core::cell::RefCell;
 use core::pin::Pin;
-use pin_cell::*;
+use pin_cell::{PinCell, PinMut};
 
 #[allow(dead_code)]
 pub fn app_main() {

--- a/rust-app/src/settings.rs
+++ b/rust-app/src/settings.rs
@@ -1,4 +1,4 @@
-use ledger_device_sdk::nvm::*;
+use ledger_device_sdk::nvm::{AtomicStorage, SingleStorage};
 use ledger_device_sdk::NVMData;
 
 // This is necessary to store the object in NVM and not in RAM

--- a/rust-app/src/utils.rs
+++ b/rust-app/src/utils.rs
@@ -50,8 +50,8 @@ pub fn scroller_paginated<F: for<'b> Fn(&mut PromptWrite<'b, 16>) -> Result<(), 
 }
 
 use core::future::Future;
-use core::pin::*;
-use core::task::*;
+use core::pin::Pin;
+use core::task::{Context, Poll};
 use pin_project::pin_project;
 #[pin_project]
 pub struct NoinlineFut<F: Future>(#[pin] pub F);

--- a/rust-app/tests/ts-tests.rs
+++ b/rust-app/tests/ts-tests.rs
@@ -5,7 +5,7 @@
 
 use ledger_device_sdk::exit_app;
 
-use iota::main_nanos::*;
+use iota::main_nanos::app_main;
 
 #[no_mangle]
 extern "C" fn sample_main() {


### PR DESCRIPTION
We are generally against wildcard imports.
This PR could have waited a bit more but since pretty much everything is feature-gated, it makes it extremely painful to work with editors that don't show where symbols are from.