### PR TITLE
fix!: don't display sender address as it would crash the app

### DIFF
--- a/rust-app/src/implementation.rs
+++ b/rust-app/src/implementation.rs
@@ -716,27 +716,6 @@ pub async fn sign_apdu(io: HostIO, settings: Settings) {
         if scroller("Transfer", |w| Ok(write!(w, "IOTA")?)).is_none() {
             reject::<()>(StatusWords::UserCancelled as u16).await;
         };
-        {
-            let mut bs = input[1].clone();
-            NoinlineFut(async move {
-                let path = BIP_PATH_PARSER.parse(&mut bs).await;
-                if !is_bip_prefix_valid(&path) {
-                    reject::<()>(SyscallError::InvalidParameter as u16).await;
-                }
-                if with_public_keys(&path, true, |_, address: &IotaPubKeyAddress| {
-                    try_option(|| -> Option<()> {
-                        scroller_paginated("From", |w| Ok(write!(w, "{address}")?))?;
-                        Some(())
-                    }())
-                })
-                .ok()
-                .is_none()
-                {
-                    reject::<()>(StatusWords::UserCancelled as u16).await;
-                }
-            })
-            .await
-        };
 
         {
             let mut txn = input[0].clone();


### PR DESCRIPTION
Don't display sender address as it would crash the app on nanos (plus and x works) when trying to read data again from the ByteStream in `input[0]` after calling `with_public_keys()`.
The example ui flow for signing also doesn't show the sender address https://developers.ledger.com/docs/device-app/develop/ui/flows/display-management-flow, so it doesn't seem to be required.
It was also not verified that this address was indeed the sender of this transaction.

Fixes https://github.com/iotaledger/ledger-app-iota/issues/11