### PR TITLE
feat: change name to iota_rebased

### DIFF
--- a/rust-app/Cargo.lock
+++ b/rust-app/Cargo.lock
@@ -355,7 +355,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "iota"
+name = "iota_rebased"
 version = "0.9.0"
 dependencies = [
  "alamgu-async-block",

--- a/rust-app/Cargo.toml
+++ b/rust-app/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "iota"
+name = "iota_rebased"
 version = "0.9.0"
 authors = ["IOTA Foundation <info@iota.org>"]
 edition = "2018"

--- a/rust-app/bin-src/main.rs
+++ b/rust-app/bin-src/main.rs
@@ -4,7 +4,7 @@
 #[cfg(not(target_family = "bolos"))]
 fn main() {}
 
-use iota::main_nanos::app_main;
+use iota_rebased::main_nanos::app_main;
 
 ledger_device_sdk::set_panic!(ledger_device_sdk::exiting_panic);
 

--- a/rust-app/tests/ts-tests.rs
+++ b/rust-app/tests/ts-tests.rs
@@ -5,7 +5,7 @@
 
 use ledger_device_sdk::exit_app;
 
-use iota::main_nanos::app_main;
+use iota_rebased::main_nanos::app_main;
 
 #[no_mangle]
 extern "C" fn sample_main() {


### PR DESCRIPTION
Change the name in the Cargo.toml so the ledger guidelines_enforcer workflow can find the correct entry in the https://github.com/LedgerHQ/ledger-app-database/edit/main/app-load-params-db.json
Failed here before: https://github.com/iotaledger/ledger-app-iota/actions/runs/11596691809/job/33527549179
