### PR TITLE
fix(CI): fix upload assets and bump ledger dependencies

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,6 +42,7 @@ jobs:
           cp ${{ needs.call_get_app_metadata.outputs.build_directory }}/compiled_app_binaries/flex/release/iota flex/
           cp ${{ needs.call_get_app_metadata.outputs.build_directory }}/compiled_app_binaries/flex/release/iota.hex  flex/
           cp ${{ needs.call_get_app_metadata.outputs.build_directory }}/compiled_app_binaries/flex/release/app_flex.json  flex/
+          mkdir -p flex/icons
           cp rust-app/icons/iota_40x40.gif flex/icons/
           tar cfzv flex.tar.gz flex
 
@@ -49,6 +50,7 @@ jobs:
           cp ${{ needs.call_get_app_metadata.outputs.build_directory }}/compiled_app_binaries/nanosplus/release/iota nanosplus/
           cp ${{ needs.call_get_app_metadata.outputs.build_directory }}/compiled_app_binaries/nanosplus/release/iota.hex nanosplus/
           cp ${{ needs.call_get_app_metadata.outputs.build_directory }}/compiled_app_binaries/nanosplus/release/app_nanosplus.json nanosplus/
+          mkdir -p nanosplus/icons
           cp rust-app/icons/iota_14x14.gif nanosplus/icons/
           tar cfzv nanosplus.tar.gz nanosplus
 
@@ -56,13 +58,15 @@ jobs:
           cp ${{ needs.call_get_app_metadata.outputs.build_directory }}/compiled_app_binaries/nanox/release/iota nanox/
           cp ${{ needs.call_get_app_metadata.outputs.build_directory }}/compiled_app_binaries/nanox/release/iota.hex nanox/
           cp ${{ needs.call_get_app_metadata.outputs.build_directory }}/compiled_app_binaries/nanox/release/app_nanox.json nanox/
+          mkdir -p nanox/icons
           cp rust-app/icons/iota_14x14.gif nanox/icons/
           tar cfzv nanox.tar.gz nanox
-          
+
           mkdir stax
           cp ${{ needs.call_get_app_metadata.outputs.build_directory }}/compiled_app_binaries/stax/release/iota stax/
           cp ${{ needs.call_get_app_metadata.outputs.build_directory }}/compiled_app_binaries/stax/release/iota.hex  stax/
           cp ${{ needs.call_get_app_metadata.outputs.build_directory }}/compiled_app_binaries/stax/release/app_stax.json  stax/
+          mkdir -p stax/icons
           cp rust-app/icons/iota_32x32.gif stax/icons/
           tar cfzv stax.tar.gz stax
 

--- a/rust-app/Cargo.lock
+++ b/rust-app/Cargo.lock
@@ -715,9 +715,9 @@ dependencies = [
 
 [[package]]
 name = "ledger_device_sdk"
-version = "1.24.7"
+version = "1.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29544d88a9190ba6aeca69123b1cb6c4082758c6c11bfefe1214d73b15c495d5"
+checksum = "d99e6282d35ce40042895e6f34f91fa9a56aa2ec304691d71957053c586666bc"
 dependencies = [
  "const-zero",
  "include_gif",
@@ -730,9 +730,9 @@ dependencies = [
 
 [[package]]
 name = "ledger_secure_sdk_sys"
-version = "1.11.1"
+version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e484986fd20c0e260507ad2125e1acaf8b12d670b64a66d5b88228b9f906f20"
+checksum = "e1b19cb4b5bcb8125ea4f5f6c0dcd409a4ec9ed9b4af0302e441b4afee379454"
 dependencies = [
  "bindgen",
  "cc",

--- a/rust-app/Cargo.toml
+++ b/rust-app/Cargo.toml
@@ -40,11 +40,11 @@ extra_debug = ["ledger-log/log_trace"]
 pending_review_screen = []
 
 [target.'cfg(target_family = "bolos")'.dependencies]
-ledger_device_sdk = "1.24.7"
-ledger_secure_sdk_sys = "1.11.1"
+ledger_device_sdk = "1.27.1"
+ledger_secure_sdk_sys = "1.11.3"
 
 [target.'cfg(target_family = "bolos")'.dev-dependencies.ledger_device_sdk]
-version = "1.24.7"
+version = "1.27.1"
 features = ["speculos"]
 
 [[bin]]

--- a/rust-app/src/ui/nbgl.rs
+++ b/rust-app/src/ui/nbgl.rs
@@ -41,7 +41,7 @@ impl UserInterface {
         self.do_refresh.replace(true);
         let success = NbglAddressReview::new()
             .glyph(&APP_ICON)
-            .verify_str("Provide Public Key")
+            .review_title("Provide Public Key")
             .show(&format!("{address}"));
         NbglReviewStatus::new()
             .status_type(StatusType::Address)


### PR DESCRIPTION
The folder needs to be created first before we can copy a file into it. It failed here https://github.com/iotaledger/ledger-app-iota/actions/runs/18338143687/job/52227036016
Bumped ledger dependencies so the CI passes, `review_title()` was suggested by a warning, because the previous `verify_str()` is deprecated